### PR TITLE
Migrate fully to RxJS 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,11 +31,9 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-0": "^6.5.0",
     "html-webpack-plugin": "^2.17.0",
-    "rxjs-es": "/Users/davidk5.0.0-beta.11",
     "webpack": "^1.13.1"
   },
   "dependencies": {
-    "rx-dom": "^7.0.3",
     "rxjs": "^5.0.0-beta.8"
   }
 }

--- a/src/animationFrame.js
+++ b/src/animationFrame.js
@@ -4,11 +4,11 @@ const animationFrame$ = Observable.create((observer) => {
   let active = true;
 
   const dispatch = () => {
-    observer.onNext(null);
-    
+    observer.next(null);
+
     if (active) requestAnimationFrame(dispatch);
   }
-  
+
   dispatch();
 
   return () => active = false;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,10 @@
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/operator/map';
+import 'rxjs/observable/of';
+import 'rxjs/observable/merge';
+
+import { Subject } from 'rxjs/Subject';
+
 import unit from './unit';
 import rect from './rect';
 
@@ -33,7 +39,7 @@ function RxCSS(observableMap) {
       let observable = observableMap[key];
 
       if (!(observable instanceof Observable)) {
-        observable = Observable.just(observableMap[key]);
+        observable = Observable.of(observableMap[key]);
       }
 
       return observable.map((val) => ({ [key]: val }));
@@ -42,7 +48,7 @@ function RxCSS(observableMap) {
   style$.subscribe((style) => {
     const nextState = {...state, ...style};
     styledash.set(style);
-    subject$.onNext(nextState);
+    subject$.next(nextState);
   });
 
   return subject$;

--- a/src/rect.js
+++ b/src/rect.js
@@ -1,4 +1,5 @@
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/operator/map';
 
 export default function rect(node, sampler = Observable.just(null)) {
   return sampler.map(() => node.getBoundingClientRect());


### PR DESCRIPTION
- Took out unused dependence on rx-dom (which used RxJS 4 underneath)
- Migrated from `just` --> `of`
- Migrated from `onNext` --> `next`
- Relied on operator patching to make a teeny bundle

As for _why_ I did this, I watched your talk and wanted to try it out. When trying to use it on codepen, I was running into problems where `latest` required RxJS 5 yet wasn't compatible with the code base here. ¯\_(ツ)_/¯

Regardless, want to play with this and learn from you.
